### PR TITLE
handle non working configurations

### DIFF
--- a/src/pipecat/services/ojin/video.py
+++ b/src/pipecat/services/ojin/video.py
@@ -898,7 +898,7 @@ class OjinPersonaService(FrameProcessor):
             elif message.payload.code == "FAILED_CREATE_MODEL":
                 is_fatal = True
                 logger.error("Ojin couldn't create a model from supplied persona ID.")
-            elif message.payload.code == "INVALID_PERSONA_ID":
+            elif message.payload.code == "INVALID_PERSONA_ID_CONFIGURATION":
                 is_fatal = True
                 logger.error("Ojin couldn't load the configuration from the supplied persona ID.")
 

--- a/src/pipecat/services/ojin/video.py
+++ b/src/pipecat/services/ojin/video.py
@@ -898,6 +898,9 @@ class OjinPersonaService(FrameProcessor):
             elif message.payload.code == "FAILED_CREATE_MODEL":
                 is_fatal = True
                 logger.error("Ojin couldn't create a model from supplied persona ID.")
+            elif message.payload.code == "INVALID_PERSONA_ID":
+                is_fatal = True
+                logger.error("Ojin couldn't load the configuration from the supplied persona ID.")
 
             if is_fatal:
                 await self.push_frame(EndFrame(), FrameDirection.UPSTREAM)


### PR DESCRIPTION
This pull request introduces improved error handling for invalid persona IDs in the Ojin video service. Now, if an invalid persona ID is encountered, the service logs a clear error message and treats the error as fatal, ensuring consistent handling of configuration issues.

Error handling improvements:

* Added a check for the `"INVALID_PERSONA_ID"` error code in `_handle_ojin_message`, logging a specific error message and marking the error as fatal to trigger proper upstream handling.