### PR TITLE
fix(ojin/video): always emit OjinBotStoppedSpeakingFrame and clear sp…

### DIFF
--- a/examples/ojin-chatbot/utils/frame_metrics.py
+++ b/examples/ojin-chatbot/utils/frame_metrics.py
@@ -63,7 +63,7 @@ class FrameMetricsProcessor(FrameProcessor):
             elapsed_ns = now_ns - self._last_fps_report_time_ns
             if elapsed_ns >= self._log_interval_ns and elapsed_ns > 0:
                 fps = self._frame_count_since_report / (elapsed_ns / 1e9)
-                logger.info(f"[FrameMetrics] Output FPS: {fps:.2f} over {elapsed_ns/1e9:.2f}s")
+                logger.info(f"[FrameMetrics] Output FPS: {fps:.2f} over {elapsed_ns / 1e9:.2f}s")
                 # Reset window
                 self._last_fps_report_time_ns = now_ns
                 self._frame_count_since_report = 0

--- a/examples/ojin-chatbot/utils/tk_overlay.py
+++ b/examples/ojin-chatbot/utils/tk_overlay.py
@@ -3,11 +3,12 @@ import tkinter as tk
 from typing import Optional
 
 from loguru import logger
-
 from ojin.profiling_utils import FPSTracker
 
 
-def create_fps_overlay(tk_root: tk.Tk, x: int = 8, y: int = 8, width: int = 160, height: int = 60) -> tk.Canvas:
+def create_fps_overlay(
+    tk_root: tk.Tk, x: int = 8, y: int = 8, width: int = 160, height: int = 60
+) -> tk.Canvas:
     """Create and place a small FPS overlay Canvas on the given Tk root.
 
     Returns the created Canvas. The caller owns placement coordinates.
@@ -17,13 +18,7 @@ def create_fps_overlay(tk_root: tk.Tk, x: int = 8, y: int = 8, width: int = 160,
         root_bg = tk_root.cget("bg")
     except Exception:
         root_bg = "#000000"
-    canvas = tk.Canvas(
-        tk_root,
-        width=width,
-        height=height,
-        highlightthickness=0,
-        bg=root_bg
-    )
+    canvas = tk.Canvas(tk_root, width=width, height=height, highlightthickness=0, bg=root_bg)
     canvas.place(x=x, y=y)
     return canvas
     # Raise the widget in the stacking order (not canvas items)
@@ -32,7 +27,9 @@ def create_fps_overlay(tk_root: tk.Tk, x: int = 8, y: int = 8, width: int = 160,
     # tk_root.after(0, lambda: tk_root.tk.call('raise', canvas._w))
 
 
-async def _draw_fps_overlay(canvas: tk.Canvas, fps_tracker: FPSTracker, width: int, height: int) -> None:
+async def _draw_fps_overlay(
+    canvas: tk.Canvas, fps_tracker: FPSTracker, width: int, height: int
+) -> None:
     # Background panel
     canvas.delete("all")
     canvas.create_rectangle(0, 0, width, height, fill="#111111", outline="#333333")
@@ -41,17 +38,29 @@ async def _draw_fps_overlay(canvas: tk.Canvas, fps_tracker: FPSTracker, width: i
     partial_history = fps_tracker.get_partial_fps_history()
     current_partial = fps_tracker.partial_average_fps
     current = fps_tracker.average_fps
-    fps_tracker.register_history()    
+    fps_tracker.register_history()
     fps_tracker.reset_partial_average()
 
     # Grid/reference lines (30 and 60 fps)
     ref_lines = [5.0, 10.0, 15.0, 20.0, 25.0, 30.0, 35.0, 40.0, 45.0, 50.0, 55.0, 60.0]
-    max_v = max(35.0, max(history) if history else 0.0, max(partial_history) if partial_history else 0.0, 1.0)
+    max_v = max(
+        35.0,
+        max(history) if history else 0.0,
+        max(partial_history) if partial_history else 0.0,
+        1.0,
+    )
     for val in ref_lines:
         y = height - int((val / max_v) * (height - 14)) - 12
         color = "#333333" if val != 60.0 else "#2a2a2a"
         canvas.create_line(2, y, width - 2, y, fill=color)
-        canvas.create_text(width - 20, y - 1, text=f"{int(val)}", anchor="ne", fill="#555555", font=("TkDefaultFont", 7))
+        canvas.create_text(
+            width - 20,
+            y - 1,
+            text=f"{int(val)}",
+            anchor="ne",
+            fill="#555555",
+            font=("TkDefaultFont", 7),
+        )
 
     # Plot FPS history as a line
     left_pad, right_pad = 2, 2
@@ -92,9 +101,23 @@ async def _draw_fps_overlay(canvas: tk.Canvas, fps_tracker: FPSTracker, width: i
             canvas.create_line(*flat_p, fill="#ffb347")
 
     # Current FPS text
-    canvas.create_text(6, 4, anchor="nw", fill="#00ff88", font=("TkDefaultFont", 9, "bold"), text=f"{current:.1f} total fps")
-    canvas.create_text(6, 24, anchor="nw", fill="#ffb347", font=("TkDefaultFont", 9, "bold"), text=f"{current_partial:.1f} partial fps")
-    #canvas.lift()
+    canvas.create_text(
+        6,
+        4,
+        anchor="nw",
+        fill="#00ff88",
+        font=("TkDefaultFont", 9, "bold"),
+        text=f"{current:.1f} total fps",
+    )
+    canvas.create_text(
+        6,
+        24,
+        anchor="nw",
+        fill="#ffb347",
+        font=("TkDefaultFont", 9, "bold"),
+        text=f"{current_partial:.1f} partial fps",
+    )
+    # canvas.lift()
 
 
 async def update_tk_root(tk_root: tk.Tk, interval_ms: int = 10) -> None:
@@ -118,7 +141,10 @@ async def update_tk_root(tk_root: tk.Tk, interval_ms: int = 10) -> None:
             logger.error(f"Error updating Tkinter: {e}")
             break
 
-async def update_tk_with_fps_periodically(tk_root: tk.Tk, fps_tracker: FPSTracker, canvas: Optional[tk.Canvas], interval_ms: int = 10) -> None:
+
+async def update_tk_with_fps_periodically(
+    tk_root: tk.Tk, fps_tracker: FPSTracker, canvas: Optional[tk.Canvas], interval_ms: int = 10
+) -> None:
     """Periodically process Tk events and render the FPS overlay.
 
     - tk_root: the Tk root to update
@@ -148,7 +174,7 @@ async def update_tk_with_fps_periodically(tk_root: tk.Tk, fps_tracker: FPSTracke
                     pass
                 # Keep overlay on top
                 try:
-                    tk_root.tk.call('raise', canvas._w)
+                    tk_root.tk.call("raise", canvas._w)
                 except Exception:
                     pass
             await asyncio.sleep(interval_ms / 1000.0)
@@ -163,6 +189,11 @@ def start_tk_updater(tk_root: tk.Tk, interval_ms: int = 10) -> asyncio.Task:
     """Start the periodic Tk updater + FPS renderer as a background task."""
     return asyncio.create_task(update_tk_root(tk_root, interval_ms))
 
-def start_tk_fps_udpater(tk_root: tk.Tk, canvas: Optional[tk.Canvas], fps_tracker: FPSTracker, interval_ms: int = 10) -> asyncio.Task:
+
+def start_tk_fps_udpater(
+    tk_root: tk.Tk, canvas: Optional[tk.Canvas], fps_tracker: FPSTracker, interval_ms: int = 10
+) -> asyncio.Task:
     """Start the periodic Tk updater + FPS renderer as a background task."""
-    return asyncio.create_task(update_tk_with_fps_periodically(tk_root, canvas, fps_tracker, interval_ms))
+    return asyncio.create_task(
+        update_tk_with_fps_periodically(tk_root, canvas, fps_tracker, interval_ms)
+    )

--- a/examples/ojin-tts/example.py
+++ b/examples/ojin-tts/example.py
@@ -20,21 +20,21 @@ from loguru import logger
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
 
 from pipecat.audio.vad.silero import SileroVADAnalyzer
-from pipecat.frames.frames import Frame, TextFrame, LLMFullResponseEndFrame, TTSSpeakFrame
+from pipecat.frames.frames import Frame, LLMFullResponseEndFrame, TextFrame, TTSSpeakFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
 from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
-from pipecat.services.openai.llm import OpenAILLMService
-from pipecat.services.whisper.stt import WhisperSTTService, Model
 from pipecat.services.ojin.tts import OjinTTSService, OjinTTSServiceSettings
+from pipecat.services.openai.llm import OpenAILLMService
+from pipecat.services.whisper.stt import Model, WhisperSTTService
 from pipecat.transports.local.audio import LocalAudioTransport, LocalAudioTransportParams
 
 
 class LLMFullResponseAggregator(FrameProcessor):
     """Aggregates LLM text tokens into a complete response before sending to TTS.
-    
+
     This processor buffers all TextFrames until LLMFullResponseEndFrame is received,
     then emits a single TTSSpeakFrame with the complete text. This allows TTS to
     have full context for better prosody and intonation.
@@ -62,6 +62,7 @@ class LLMFullResponseAggregator(FrameProcessor):
             # Pass through other frames
             await self.push_frame(frame, direction)
 
+
 load_dotenv(override=True)
 
 logger.remove(0)
@@ -70,13 +71,13 @@ logger.add(sys.stderr, level="DEBUG")
 
 async def main():
     """Run the speech-to-speech pipeline."""
-    
+
     # Validate environment variables
     openai_api_key = os.getenv("OPENAI_API_KEY")
     ojin_api_key = os.getenv("OJIN_API_KEY")
     ojin_config_id = os.getenv("OJIN_TTS_CONFIG_ID")
     ws_url = os.getenv("OJIN_WS_URL", "wss://models.ojin.ai/realtime")
-    
+
     if not openai_api_key:
         logger.error("OPENAI_API_KEY not set in environment")
         return
@@ -102,7 +103,7 @@ async def main():
     # Speech-to-Text using local Whisper (CPU mode for compatibility)
     stt = WhisperSTTService(
         model=Model.TINY,  # Use tiny model for faster inference
-        device="cpu",      # Force CPU to avoid CUDA dependency
+        device="cpu",  # Force CPU to avoid CUDA dependency
     )
 
     # LLM using OpenAI
@@ -163,14 +164,14 @@ async def main():
     # Audio In -> STT -> User Context -> LLM -> Aggregator -> TTS -> Audio Out -> Assistant Context
     pipeline = Pipeline(
         [
-            audio_transport.input(),       # Microphone input + VAD
-            stt,                           # Speech-to-Text (Whisper)
-            context_aggregator.user(),     # Add user message to context
-            llm,                           # LLM generates response tokens
-            response_aggregator,           # Buffer full response before TTS
-            tts,                           # Ojin TTS converts to audio
-            audio_transport.output(),      # Speaker output
-            context_aggregator.assistant(), # Add assistant response to context
+            audio_transport.input(),  # Microphone input + VAD
+            stt,  # Speech-to-Text (Whisper)
+            context_aggregator.user(),  # Add user message to context
+            llm,  # LLM generates response tokens
+            response_aggregator,  # Buffer full response before TTS
+            tts,  # Ojin TTS converts to audio
+            audio_transport.output(),  # Speaker output
+            context_aggregator.assistant(),  # Add assistant response to context
         ]
     )
 
@@ -186,7 +187,7 @@ async def main():
 
     # Run the pipeline (handle_sigint=False for Windows compatibility)
     runner = PipelineRunner(handle_sigint=False)
-    
+
     logger.info("=" * 50)
     logger.info("Speech-to-Speech Pipeline Started!")
     logger.info("Speak into your microphone to interact.")

--- a/src/pipecat/services/hume/hume.py
+++ b/src/pipecat/services/hume/hume.py
@@ -63,6 +63,8 @@ from pipecat.utils.time import time_now_iso8601
 
 @dataclass
 class HumeStartFrame(SystemFrame):
+    """System frame that triggers HumeSTSService to connect to the Hume EVI websocket."""
+
     pass
 
 
@@ -85,6 +87,7 @@ class HumeSTSService(LLMService):
         audio_passthrough: bool = False,
         **kwargs,
     ):
+        """Initialize the HumeSTSService with API credentials and conversation settings."""
         super().__init__(**kwargs)
         logger.debug("Initializing HumeSTSService")
         self._audio_passthrough = audio_passthrough
@@ -106,22 +109,27 @@ class HumeSTSService(LLMService):
         self._start_frame_cls = start_frame_cls or HumeStartFrame
 
     async def start(self, frame: StartFrame):
+        """Start the service in response to a StartFrame."""
         await super().start(frame)
 
     async def stop(self, frame: EndFrame):
+        """Stop the service and disconnect from Hume."""
         await super().stop(frame)
         await self._disconnect()
 
     async def cancel(self, frame: CancelFrame):
+        """Cancel the service and disconnect from Hume."""
         await super().cancel(frame)
         await self._disconnect()
 
     async def reset_conversation(self):
+        """Reconnect to Hume and reset the active-conversation state."""
         await self._disconnect()
         await self._connect()
         self.active_conversation = False
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
+        """Route incoming frames to the Hume websocket and handle interruption/audio frames."""
         await super().process_frame(frame, direction)
         if isinstance(frame, self._start_frame_cls):
             logger.info("Starting Hume service")

--- a/src/pipecat/services/hume/hume_client.py
+++ b/src/pipecat/services/hume/hume_client.py
@@ -1,4 +1,5 @@
 """Hume.ai EVI (Empathic Voice Interface) WebSocket client.
+
 Handles speech-to-speech conversation with Hume's API.
 """
 
@@ -17,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 class SimpleHumeClient:
     """Simplified Hume client using direct WebSocket connection.
+
     More control over the connection for our POC.
     """
 
@@ -27,6 +29,7 @@ class SimpleHumeClient:
         config_id: str | None = None,
         system_prompt: str | None = None,
     ):
+        """Initialize the client with a message callback and optional Hume credentials."""
         self.on_message = on_message
         self.api_key = api_key or os.getenv("HUME_API_KEY")
         self.config_id = config_id or os.getenv("HUME_CONFIG_ID")

--- a/src/pipecat/services/ojin/tts.py
+++ b/src/pipecat/services/ojin/tts.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: BSD 2-Clause License
 #
+"""Ojin TTS service: streams text to the Ojin inference server and yields audio frames."""
 
 import asyncio
 import os
@@ -72,6 +73,7 @@ class OjinTTSService(TTSService):
         client: IOjinClient | None = None,
         **kwargs,
     ) -> None:
+        """Initialize the OjinTTSService with settings and an optional Ojin client."""
         super().__init__(sample_rate=settings.sample_rate, **kwargs)
         logger.debug(f"OjinTTSService initialized with settings {settings}")
 
@@ -93,6 +95,7 @@ class OjinTTSService(TTSService):
         self._audio_queue: asyncio.Queue[OjinInteractionResponseMessage | None] = asyncio.Queue()
 
     def can_generate_metrics(self) -> bool:
+        """Enable TTFB metrics reporting via the standard pipecat metrics system."""
         return True
 
     async def connect_with_retry(self) -> bool:
@@ -324,5 +327,6 @@ class OjinTTSServiceInitializedFrame(Frame):
     """Frame indicating that the TTS service has been initialized."""
 
     def __init__(self, session_data: Optional[Dict[str, Any]] = None):
+        """Initialize the frame with optional session metadata from the Ojin server."""
         super().__init__()
         self.session_data = session_data

--- a/src/pipecat/services/ojin/video.py
+++ b/src/pipecat/services/ojin/video.py
@@ -709,9 +709,6 @@ class OjinVideoService(FrameProcessor):
         await self.stop_ttfb_metrics()
 
     async def _stop_audio_playback(self):
-        if not self._is_playing_speech_audio:
-            return
-
         self._is_playing_speech_audio = False
         await self.push_frame(OjinBotStoppedSpeakingFrame(), direction=FrameDirection.DOWNSTREAM)
         self._speech_buffer.clear()

--- a/src/pipecat/services/ojin/video.py
+++ b/src/pipecat/services/ojin/video.py
@@ -80,6 +80,7 @@ class VideoFrame:
     is_first_speech_frame: bool = False
 
     def is_silence(self) -> bool:
+        """Return True if this frame is a silence placeholder (frame_idx == 0)."""
         return self.frame_idx == 0
 
 
@@ -132,6 +133,7 @@ class OjinVideoService(FrameProcessor):
         settings: OjinVideoSettings,
         client: IOjinClient | None = None,
     ) -> None:
+        """Initialize the OjinVideoService with settings and an optional Ojin client."""
         super().__init__(name="ojin")
         logger.debug(
             f"OjinVideoService initialized with settings {settings} version: {OJIN_VIDEO_SERVICE_VERSION}"
@@ -554,7 +556,7 @@ class OjinVideoService(FrameProcessor):
 
             # ── Step 2: Prepare audio ──
             if self._is_playing_speech_audio and self._speech_buffer:
-                if len(self._speech_buffer) < chunk_size:                    
+                if len(self._speech_buffer) < chunk_size:
                     audio = bytes(self._speech_buffer)
                     self._speech_buffer.clear()
                 else:
@@ -728,6 +730,7 @@ class OjinVideoService(FrameProcessor):
     async def prepare_video_frame(
         self, video: bytes, is_first: bool = False, pts: Optional[int] = None
     ) -> OutputImageRawFrame:
+        """Decode raw video bytes and wrap them in an OutputImageRawFrame for the transport."""
         if pts is None:
             pts = int(time.monotonic() * 1_000_000_000)
         image_array = np.frombuffer(video, dtype=np.uint8)

--- a/src/pipecat/services/openai/base_llm.py
+++ b/src/pipecat/services/openai/base_llm.py
@@ -270,18 +270,14 @@ class BaseOpenAILLMService(LLMService):
         _has_tools = tools_param is not None and tools_param is not NOT_GIVEN and bool(tools_param)
         if _has_tools:
             _tool_names = [
-                t.get("function", {}).get("name", "?")
-                for t in tools_param
-                if isinstance(t, dict)
+                t.get("function", {}).get("name", "?") for t in tools_param if isinstance(t, dict)
             ]
             logger.info(
                 f"🔧 {self}: API request tools={_tool_names}, "
                 f"tool_choice={tool_choice_param}, model={params.get('model')}"
             )
         else:
-            logger.info(
-                f"🔧 {self}: API request with NO tools, model={params.get('model')}"
-            )
+            logger.info(f"🔧 {self}: API request with NO tools, model={params.get('model')}")
 
         return params
 
@@ -441,7 +437,7 @@ class BaseOpenAILLMService(LLMService):
                 if tool_call.function and tool_call.function.arguments:
                     # Keep iterating through the response to collect all the argument fragments
                     arguments += tool_call.function.arguments
-            elif chunk.choices[0].delta.content:                
+            elif chunk.choices[0].delta.content:
                 await self.push_frame(LLMTextFrame(chunk.choices[0].delta.content))
 
             # When gpt-4o-audio / gpt-4o-mini-audio is used for llm or stt+llm
@@ -459,9 +455,7 @@ class BaseOpenAILLMService(LLMService):
                 f"ids={tool_id_list + [tool_call_id]}"
             )
         else:
-            logger.info(
-                f"🔧 {self}: API response contains NO native tool_calls (text-only output)"
-            )
+            logger.info(f"🔧 {self}: API response contains NO native tool_calls (text-only output)")
 
         # if we got a function name and arguments, check to see if it's a function with
         # a registered handler. If so, run the registered callback, save the result to

--- a/tests/test_ojin_video_service.py
+++ b/tests/test_ojin_video_service.py
@@ -8,12 +8,14 @@
 import sys
 from unittest.mock import MagicMock
 
-# The 'ojin' package (provided by ojin-client) is required by pipecat's
-# ojin services at import time, but CI does not install it (--extra ojin
-# is intentionally excluded from the workflow's `uv sync` call). Stub the
-# modules we transitively pull in so the test file can import
-# OjinVideoService without the real package present.
+# The 'ojin' package (provided by ojin-client) and cv2 (opencv-python,
+# from --extra webrtc) are imported at module load by
+# pipecat.services.ojin.video, but CI's tests workflow installs neither.
+# Stub them so the test file can import OjinVideoService; the test only
+# exercises _stop_audio_playback, which does not touch any stubbed
+# attribute at runtime.
 for _name in (
+    "cv2",
     "ojin",
     "ojin.entities",
     "ojin.entities.interaction_messages",

--- a/tests/test_ojin_video_service.py
+++ b/tests/test_ojin_video_service.py
@@ -3,12 +3,31 @@
 #
 # SPDX-License-Identifier: BSD 2-Clause License
 #
+"""Regression tests for OjinVideoService._stop_audio_playback."""
 
-import unittest
-from unittest.mock import AsyncMock, MagicMock
+import sys
+from unittest.mock import MagicMock
 
-from pipecat.processors.frame_processor import FrameDirection
-from pipecat.services.ojin.video import (
+# The 'ojin' package (provided by ojin-client) is required by pipecat's
+# ojin services at import time, but CI does not install it (--extra ojin
+# is intentionally excluded from the workflow's `uv sync` call). Stub the
+# modules we transitively pull in so the test file can import
+# OjinVideoService without the real package present.
+for _name in (
+    "ojin",
+    "ojin.entities",
+    "ojin.entities.interaction_messages",
+    "ojin.ojin_client",
+    "ojin.ojin_client_messages",
+    "ojin.profiling_utils",
+):
+    sys.modules.setdefault(_name, MagicMock())
+
+import unittest  # noqa: E402
+from unittest.mock import AsyncMock  # noqa: E402
+
+from pipecat.processors.frame_processor import FrameDirection  # noqa: E402
+from pipecat.services.ojin.video import (  # noqa: E402
     OjinBotStoppedSpeakingFrame,
     OjinVideoService,
     OjinVideoSettings,
@@ -56,9 +75,7 @@ class TestStopAudioPlayback(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(service._is_playing_speech_audio)
         self.assertEqual(len(service._speech_buffer), 0)
         service.push_frame.assert_awaited_once()
-        self.assertIsInstance(
-            service.push_frame.call_args.args[0], OjinBotStoppedSpeakingFrame
-        )
+        self.assertIsInstance(service.push_frame.call_args.args[0], OjinBotStoppedSpeakingFrame)
 
     async def test_idempotent_across_repeated_calls(self):
         # Calling twice in a row should remain consistent: the flag stays

--- a/tests/test_ojin_video_service.py
+++ b/tests/test_ojin_video_service.py
@@ -1,0 +1,83 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from pipecat.processors.frame_processor import FrameDirection
+from pipecat.services.ojin.video import (
+    OjinBotStoppedSpeakingFrame,
+    OjinVideoService,
+    OjinVideoSettings,
+)
+
+
+def _make_service() -> OjinVideoService:
+    """Build an OjinVideoService with a mocked client and a stubbed push_frame."""
+    settings = OjinVideoSettings()
+    service = OjinVideoService(settings=settings, client=MagicMock())
+    service.push_frame = AsyncMock()
+    return service
+
+
+class TestStopAudioPlayback(unittest.IsolatedAsyncioTestCase):
+    async def test_emits_frame_when_flag_already_false(self):
+        # Regression scenario: _video_playback_loop's natural-end branch
+        # pre-sets the flag to False before calling _stop_audio_playback.
+        # Before the fix, the method short-circuited and skipped the frame
+        # push and buffer clear.
+        service = _make_service()
+        service._is_playing_speech_audio = False
+        service._speech_buffer.extend(b"\x00\x01\x02\x03")
+
+        await service._stop_audio_playback()
+
+        self.assertEqual(len(service._speech_buffer), 0)
+        service.push_frame.assert_awaited_once()
+        pushed_frame = service.push_frame.call_args.args[0]
+        self.assertIsInstance(pushed_frame, OjinBotStoppedSpeakingFrame)
+        self.assertEqual(
+            service.push_frame.call_args.kwargs.get("direction"),
+            FrameDirection.DOWNSTREAM,
+        )
+
+    async def test_clears_buffer_when_flag_true(self):
+        # Interruption-handler call sites (INSTANT_CUT, SMOOTH_VIDEO_HARD_AUDIO)
+        # do not pre-set the flag. Behaviour must remain correct here.
+        service = _make_service()
+        service._is_playing_speech_audio = True
+        service._speech_buffer.extend(b"\xff\xee\xdd")
+
+        await service._stop_audio_playback()
+
+        self.assertFalse(service._is_playing_speech_audio)
+        self.assertEqual(len(service._speech_buffer), 0)
+        service.push_frame.assert_awaited_once()
+        self.assertIsInstance(
+            service.push_frame.call_args.args[0], OjinBotStoppedSpeakingFrame
+        )
+
+    async def test_idempotent_across_repeated_calls(self):
+        # Calling twice in a row should remain consistent: the flag stays
+        # False and a frame is pushed each time. This guards against any
+        # future re-introduction of an early-return that would silently
+        # drop a stop signal.
+        service = _make_service()
+        service._is_playing_speech_audio = True
+        service._speech_buffer.extend(b"\x10\x20")
+
+        await service._stop_audio_playback()
+        await service._stop_audio_playback()
+
+        self.assertFalse(service._is_playing_speech_audio)
+        self.assertEqual(len(service._speech_buffer), 0)
+        self.assertEqual(service.push_frame.await_count, 2)
+        for call in service.push_frame.await_args_list:
+            self.assertIsInstance(call.args[0], OjinBotStoppedSpeakingFrame)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
…eech buffer on natural end-of-audio

Re-applying the change set originally introduced in 3d283091b (and reverted on the trunk in 2623a99da to support a clean PR review process). No code change relative to the original; resubmitting via PR.

_video_playback_loop pre-set _is_playing_speech_audio to False before calling _stop_audio_playback, which then short-circuited on its own guard and skipped both the frame push and the buffer clear. Two regressions followed: anything observing the stopped-speaking signal never saw it on the natural-end path, and consecutive bot turns played the residual audio of the previous turn over the start of the next.

Drop the early-return guard. The method is now idempotent and always emits the frame + clears the buffer. Both call sites (the pre-setting playback loop, and the interruption handlers that don't pre-set) end up correct.

Includes the regression test originally added with the fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved audio playback stopping reliability in Ojin video service

* **Documentation**
  * Added docstrings to Hume and Ojin services

* **Tests**
  * Added comprehensive test coverage for Ojin video service audio playback scenarios

* **Style**
  * Code formatting and whitespace improvements across multiple modules
<!-- end of auto-generated comment: release notes by coderabbit.ai -->