### PR TITLE
fix(ojin-video): always emit OjinBotStoppedSpeakingFrame on natural end-of-audio

### DIFF
--- a/src/pipecat/services/ojin/video.py
+++ b/src/pipecat/services/ojin/video.py
@@ -33,13 +33,13 @@ from pipecat.frames.frames import (
     CancelFrame,
     EndFrame,
     Frame,
+    InterruptionTaskFrame,
     OutputAudioRawFrame,
     OutputImageRawFrame,
     StartFrame,
     TTSAudioRawFrame,
     TTSStartedFrame,
     UserStartedSpeakingFrame,
-    InterruptionTaskFrame,
 )
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 
@@ -81,6 +81,7 @@ class VideoFrame:
     is_first_speech_frame: bool = False
 
     def is_silence(self) -> bool:
+        """Return True if this is a silence/idle frame (frame_idx 0)."""
         return self.frame_idx == 0
 
 
@@ -133,6 +134,7 @@ class OjinVideoService(FrameProcessor):
         settings: OjinVideoSettings,
         client: IOjinClient | None = None,
     ) -> None:
+        """Initialize the service with its settings and an optional Ojin client."""
         super().__init__(name="ojin")
         logger.debug(
             f"OjinVideoService initialized with settings {settings} version: {OJIN_VIDEO_SERVICE_VERSION}"
@@ -716,9 +718,13 @@ class OjinVideoService(FrameProcessor):
         await self.stop_ttfb_metrics()
 
     async def _stop_audio_playback(self):
-        if not self._is_playing_speech_audio:
-            return
-
+        # No early-return guard: the natural-end branch of _video_playback_loop
+        # pre-sets _is_playing_speech_audio to False before calling this, so a
+        # guard on that flag would short-circuit and skip both the frame push
+        # and the buffer clear. The method is idempotent and always emits the
+        # stopped-speaking signal + clears residual audio. Downstream consumers
+        # (e.g. the bot's nudge/turn state machine) gate on their own
+        # is-speaking flag, so a repeated emit is harmless.
         self._is_playing_speech_audio = False
         await self.push_frame(OjinBotStoppedSpeakingFrame(), direction=FrameDirection.DOWNSTREAM)
         self._speech_buffer.clear()
@@ -738,6 +744,7 @@ class OjinVideoService(FrameProcessor):
     async def prepare_video_frame(
         self, video: bytes, is_first: bool = False, pts: Optional[int] = None
     ) -> OutputImageRawFrame:
+        """Decode, scale-to-cover, and wrap raw JPEG bytes into an output image frame."""
         if pts is None:
             pts = int(time.monotonic() * 1_000_000_000)
         image_array = np.frombuffer(video, dtype=np.uint8)
@@ -762,7 +769,9 @@ class OjinVideoService(FrameProcessor):
             rgb_image = cv2.cvtColor(cropped, cv2.COLOR_BGR2RGB)
             rgb_bytes = rgb_image.tobytes()
 
-            rgb_frame = OutputImageRawFrame(image=rgb_bytes, size=(target_w, target_h), format="RGB")
+            rgb_frame = OutputImageRawFrame(
+                image=rgb_bytes, size=(target_w, target_h), format="RGB"
+            )
             rgb_frame.pts = pts
             if is_first:
                 logger.warning(f"First image frame played!")

--- a/tests/test_ojin_video_service.py
+++ b/tests/test_ojin_video_service.py
@@ -1,0 +1,81 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from pipecat.processors.frame_processor import FrameDirection
+from pipecat.services.ojin.video import (
+    OjinBotStoppedSpeakingFrame,
+    OjinVideoService,
+    OjinVideoSettings,
+)
+
+
+def _make_service() -> OjinVideoService:
+    """Build an OjinVideoService with a mocked client and a stubbed push_frame."""
+    settings = OjinVideoSettings()
+    service = OjinVideoService(settings=settings, client=MagicMock())
+    service.push_frame = AsyncMock()
+    return service
+
+
+class TestStopAudioPlayback(unittest.IsolatedAsyncioTestCase):
+    async def test_emits_frame_when_flag_already_false(self):
+        # Regression scenario: _video_playback_loop's natural-end branch
+        # pre-sets the flag to False before calling _stop_audio_playback.
+        # Before the fix, the method short-circuited and skipped the frame
+        # push and buffer clear.
+        service = _make_service()
+        service._is_playing_speech_audio = False
+        service._speech_buffer.extend(b"\x00\x01\x02\x03")
+
+        await service._stop_audio_playback()
+
+        self.assertEqual(len(service._speech_buffer), 0)
+        service.push_frame.assert_awaited_once()
+        pushed_frame = service.push_frame.call_args.args[0]
+        self.assertIsInstance(pushed_frame, OjinBotStoppedSpeakingFrame)
+        self.assertEqual(
+            service.push_frame.call_args.kwargs.get("direction"),
+            FrameDirection.DOWNSTREAM,
+        )
+
+    async def test_clears_buffer_when_flag_true(self):
+        # Interruption-handler call sites (INSTANT_CUT, SMOOTH_VIDEO_HARD_AUDIO)
+        # do not pre-set the flag. Behaviour must remain correct here.
+        service = _make_service()
+        service._is_playing_speech_audio = True
+        service._speech_buffer.extend(b"\xff\xee\xdd")
+
+        await service._stop_audio_playback()
+
+        self.assertFalse(service._is_playing_speech_audio)
+        self.assertEqual(len(service._speech_buffer), 0)
+        service.push_frame.assert_awaited_once()
+        self.assertIsInstance(service.push_frame.call_args.args[0], OjinBotStoppedSpeakingFrame)
+
+    async def test_idempotent_across_repeated_calls(self):
+        # Calling twice in a row should remain consistent: the flag stays
+        # False and a frame is pushed each time. This guards against any
+        # future re-introduction of an early-return that would silently
+        # drop a stop signal.
+        service = _make_service()
+        service._is_playing_speech_audio = True
+        service._speech_buffer.extend(b"\x10\x20")
+
+        await service._stop_audio_playback()
+        await service._stop_audio_playback()
+
+        self.assertFalse(service._is_playing_speech_audio)
+        self.assertEqual(len(service._speech_buffer), 0)
+        self.assertEqual(service.push_frame.await_count, 2)
+        for call in service.push_frame.await_args_list:
+            self.assertIsInstance(call.args[0], OjinBotStoppedSpeakingFrame)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

On natural end-of-audio, `OjinVideoService` never emits `OjinBotStoppedSpeakingFrame` and never clears the speech buffer.

`_video_playback_loop`'s natural-end branch pre-sets `self._is_playing_speech_audio = False` *before* calling `_stop_audio_playback()`. That method then had an early-return guard on the very same flag:

```python
async def _stop_audio_playback(self):
    if not self._is_playing_speech_audio:   # already False on the natural-end path
        return                               # -> frame push + buffer clear skipped
    self._is_playing_speech_audio = False
    await self.push_frame(OjinBotStoppedSpeakingFrame(), direction=FrameDirection.DOWNSTREAM)
    self._speech_buffer.clear()
```

So on every natural turn end the guard short-circuits. The frame *is* emitted on the interruption paths (INSTANT_CUT / SMOOTH_VIDEO_HARD_AUDIO), where the flag is still `True` — which is why the regression only shows on natural ends.

### Impact

Two downstream regressions, both seen on the human-agent bots (demo-modal-agents):

1. **Inactivity nudges never fire.** The bot's nudge/turn state machine only flips `bot_first_turn_done=True` and starts its silence countdown when it receives `OjinBotStoppedSpeakingFrame`. Without it on natural turn ends, the nudge monitor's gates never pass and no nudge is ever sent.
2. **Residual audio across turns.** The speech buffer is never cleared on natural end, so leftover audio from the previous turn can play over the start of the next.

## Fix

Drop the early-return guard. `_stop_audio_playback` becomes idempotent and always emits the stopped-speaking signal + clears residual audio. Both call sites end up correct:

- natural-end branch (pre-sets the flag to `False`) — now still emits + clears
- interruption handlers (don't pre-set) — unchanged behaviour

A repeated emit is harmless: downstream consumers gate on their own is-speaking flag.

## Tests

Adds `tests/test_ojin_video_service.py` covering the natural-end path, the interruption path, and idempotency. All pass locally (`ruff check`, `ruff format`, and pytest green).

## Note

This re-applies commit `3d283091b`, which fixed the same issue

## Relationship to `staging` (read before merging)

`staging` is `fix-replies` + 28 commits and **already fixes this**, via a different mechanism. Commit `d2072e8fb` ("session tracing + lipsync fixes") rewrote the speaking-emit logic into `_maybe_emit_started_speaking` / `_maybe_emit_stopped_speaking` (edge-detection on `_is_currently_speaking()`); `staging` has no `_stop_audio_playback` method at all, so `OjinBotStoppedSpeakingFrame` fires correctly on natural turn end there.

Consequence for downstream (`demo-modal-agents`):

- `main` pins `pipecat-ojin@fix-replies` → bug present → inactivity nudges broken.
- `feat/server-refactor` (deployed to staging) pins `pipecat-ojin@staging` → already fixed → nudges work.

So this PR is the **surgical fix for `fix-replies`** specifically. If the plan is to migrate `demo-modal-agents` onto `@staging` (as `feat/server-refactor` already does), this becomes redundant and the cleaner move is bumping the pin rather than landing this. Merge this only if `fix-replies` remains a live deploy target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced audio playback stopping to handle edge cases more reliably.

* **Documentation**
  * Updated documentation for video service initialization and frame operations.

* **Tests**
  * Added comprehensive test coverage for audio playback stopping across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
